### PR TITLE
Change VL53L0X detect mode to HIGH_SPEED

### DIFF
--- a/i2c_lidar.py
+++ b/i2c_lidar.py
@@ -29,6 +29,6 @@ def create(gpio, addr):
 
     # Create a VL53L0X object
     tof = VL53L0X.VL53L0X(address = addr)
-    tof.start_ranging(VL53L0X.VL53L0X_LONG_RANGE_MODE)
+    tof.start_ranging(VL53L0X.VL53L0X_HIGH_SPEED_MODE)
 
     return tof


### PR DESCRIPTION
Was using LONG_RANGE, which measures 2m but at 33ms
HIGH_SPEED measures 1.2m, with slightly reduced accuracy, but at 20ms

This isn't related to the bus speed problems. This is just making the laser read as fast as it can; so we can get as many readings as possible during the speed run; this change gives us approximately 50 readings per second per device instead of 30.

The trade-off is a couple of percentage points of accuracy, but that should be acceptable. We can always play around with it if not.