### PR TITLE
Use string formatting & self.show_message to reduce code duplication

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -85,21 +85,15 @@ class launcher:
 
     def show_mode(self):
         """ Show state on OLED display """
-        self.oled.cls()  # Clear Screen
-        # self.oled.canvas.text((10, 10), 'mode', fill=1)
         # Show appropriate mode
-        if self.mode == self.MODE_NONE:
-            self.oled.canvas.text((10, 10), 'Mode:', fill=1)
-        elif self.mode == self.MODE_RC:
-            self.oled.canvas.text((10, 10), 'Mode: RC', fill=1)
-        elif self.mode == self.MODE_WALL:
-            self.oled.canvas.text((10, 10), 'Mode: Wall', fill=1)
-        elif self.mode == self.MODE_MAZE:
-            self.oled.canvas.text((10, 10), 'Mode: Maze', fill=1)
-        elif self.mode == self.MODE_CALIBRATION:
-            self.oled.canvas.text((10, 10), 'Mode: Calibration', fill=1)
-        # Now show the mesasge on the screen
-        self.oled.display()
+        mode_map = {
+            self.MODE_NONE: '',
+            self.MODE_RC: 'RC',
+            self.MODE_WALL: 'Wall',
+            self.MODE_MAZE: 'Maze',
+            self.MODE_CALIBRATION: 'Calibration',
+        }
+        self.show_message('Mode: %s' % mode_map[self.mode])
 
     def show_motor_config(self, left):
         """ Show motor/aux config on OLED display """


### PR DESCRIPTION
I noticed that there was a bit of duplication in `show_mode` where the only thing different between the messages to be displayed was the substring related to the mode. So, I've simplified it by creating a map of mode to display name (which should probably be part of the mode definition itself, but one step at a time), and use that with some string formatting to build the display string.

I also removed the duplicated oled display code inside `show_code` and instead make a call to `show_message`, passing our display string.

Hope that's ok.