### PR TITLE
Update how we display messages

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -85,21 +85,15 @@ class launcher:
 
     def show_mode(self):
         """ Show state on OLED display """
-        self.oled.cls()  # Clear Screen
-        # self.oled.canvas.text((10, 10), 'mode', fill=1)
         # Show appropriate mode
-        if self.mode == self.MODE_NONE:
-            self.oled.canvas.text((10, 10), 'Mode:', fill=1)
-        elif self.mode == self.MODE_RC:
-            self.oled.canvas.text((10, 10), 'Mode: RC', fill=1)
-        elif self.mode == self.MODE_WALL:
-            self.oled.canvas.text((10, 10), 'Mode: Wall', fill=1)
-        elif self.mode == self.MODE_MAZE:
-            self.oled.canvas.text((10, 10), 'Mode: Maze', fill=1)
-        elif self.mode == self.MODE_CALIBRATION:
-            self.oled.canvas.text((10, 10), 'Mode: Calibration', fill=1)
-        # Now show the mesasge on the screen
-        self.oled.display()
+        mode_map = {
+            self.MODE_NONE: '',
+            self.MODE_RC: 'RC',
+            self.MODE_WALL: 'Wall',
+            self.MODE_MAZE: 'Maze',
+            self.MODE_CALIBRATION: 'Calibration',
+        }
+        self.show_message('Mode: %s' % mode_map[self.mode])
 
     def show_motor_config(self, left):
         """ Show motor/aux config on OLED display """

--- a/launcher.py
+++ b/launcher.py
@@ -76,11 +76,16 @@ class launcher:
         # Show state on OLED display
         self.show_mode()
 
-    def show_message(self, message):
+    def show_message(self, title, message=''):
         """ Show state on OLED display """
-        self.oled.cls()  # Clear Screen
-        self.oled.canvas.text((10, 10), message, fill=1)
-        # Now show the mesasge on the screen
+        # Clear Screen
+        self.oled.cls()
+        # Show the title
+        self.oled.canvas.text((10, 10), title, fill=1)
+        # Now show the message on the screen if required
+        if message:
+            self.oled.canvas.text((10, 30), message, fill=1)
+
         self.oled.display()
 
     def show_mode(self):

--- a/launcher.py
+++ b/launcher.py
@@ -97,35 +97,22 @@ class launcher:
 
     def show_motor_config(self, left):
         """ Show motor/aux config on OLED display """
-        if left:
-            title = "Left Motor:"
-            message = str(self.core.left_servo.servo_min) + '/'\
-                + str(self.core.left_servo.servo_mid) + '/'\
-                + str(self.core.left_servo.servo_max)
-        else:
-            title = "Right Motor:"
-            message = str(self.core.right_servo.servo_min) + '/'\
-                + str(self.core.right_servo.servo_mid) + '/'\
-                + str(self.core.right_servo.servo_max)
+        side_label = 'Left' if left else 'Right'
+        title = '%s Motor:' % side_label
+        servo = self.core.left_servo if left else self.core.right_servo
 
-        self.oled.cls()  # Clear Screen
-        self.oled.canvas.text((10, 10), title, fill=1)
-        self.oled.canvas.text((10, 30), message, fill=1)
-        # Now show the mesasge on the screen
-        self.oled.display()
+        self.display_config(title, servo)
 
     def show_aux_1_config(self, left):
         """ Show motor/aux config on OLED display """
-        if left:
-            title = "Left Aux 1:"
-            message = str(self.core.left_aux_1_servo.servo_min) + '/'\
-                + str(self.core.left_aux_1_servo.servo_mid) + '/'\
-                + str(self.core.left_aux_1_servo.servo_max)
-        else:
-            title = "Right Aux 1:"
-            message = str(self.core.right_aux_1_servo.servo_min) + '/'\
-                + str(self.core.right_aux_1_servo.servo_mid) + '/'\
-                + str(self.core.right_aux_1_servo.servo_max)
+        side_label = 'Left' if left else 'Right'
+        title = '%s Aux 1:' % side_label
+        servo = self.core.left_aux_1_servo if left else self.core.right_aux_1_servo
+
+        self.display_config(title, servo)
+
+    def display_config(self, title, servo):
+        message = '%d / %d / %d' % (servo.servo_min, servo.servo_mid, servo.servo_max)
 
         self.oled.cls()  # Clear Screen
         self.oled.canvas.text((10, 10), title, fill=1)

--- a/launcher.py
+++ b/launcher.py
@@ -76,7 +76,7 @@ class launcher:
         # Show state on OLED display
         self.show_mode()
 
-    def show_message(self, title='', message=''):
+    def set_display_contents(self, title='', message=''):
         """ Show state on OLED display """
         # Clear Screen
         self.oled.cls()
@@ -98,7 +98,7 @@ class launcher:
             self.MODE_MAZE: 'Maze',
             self.MODE_CALIBRATION: 'Calibration',
         }
-        self.show_message(title='Mode: %s' % mode_map[self.mode])
+        self.set_display_contents(title='Mode: %s' % mode_map[self.mode])
 
     def show_motor_config(self, left):
         """ Show motor/aux config on OLED display """
@@ -119,7 +119,7 @@ class launcher:
     def display_config(self, title, servo):
         message = '%d / %d / %d' % (servo.servo_min, servo.servo_mid, servo.servo_max)
 
-        self.show_message(title=title, message=message)
+        self.set_display_contents(title=title, message=message)
 
     def read_config(self):
         # Read the config file when starting up.
@@ -178,17 +178,17 @@ class launcher:
     def run(self):
         """ Main Running loop controling bot mode and menu state """
         # Show state on OLED display
-        self.show_message(title='Booting...')
+        self.set_display_contents(title='Booting...')
 
         # Read config file FIRST
         self.read_config()
 
-        self.show_message(title='Initialising Bluetooth...')
+        self.set_display_contents(title='Initialising Bluetooth...')
 
         # Never stop looking for wiimote.
         while not self.killed:
             # Show state on OLED display
-            self.show_message(
+            self.set_display_contents(
                 title='Waiting for WiiMote...',
                 message='***Press 1+2 now ***'
             )
@@ -267,4 +267,4 @@ if __name__ == "__main__":
         print("Stopping")
         print(str(e))
         # Show state on OLED display
-        launcher.show_message(title='Exited Python Code')
+        launcher.set_display_contents(title='Exited Python Code')

--- a/launcher.py
+++ b/launcher.py
@@ -100,23 +100,20 @@ class launcher:
         }
         self.set_display_contents(title='Mode: %s' % mode_map[self.mode])
 
-    def show_motor_config(self, left):
-        """ Show motor/aux config on OLED display """
-        side_label = 'Left' if left else 'Right'
-        title = '%s Motor:' % side_label
-        servo = self.core.left_servo if left else self.core.right_servo
-
-        self.display_config(title, servo)
-
-    def show_aux_1_config(self, left):
-        """ Show motor/aux config on OLED display """
-        side_label = 'Left' if left else 'Right'
-        title = '%s Aux 1:' % side_label
-        servo = self.core.left_aux_1_servo if left else self.core.right_aux_1_servo
-
-        self.display_config(title, servo)
-
     def display_config(self, title, servo):
+        # determine title template
+        if servo in [self.core.left_servo,self.core.right_servo]:
+            msg_template = '%s Motor:'
+        else:
+            msg_template = '%s Aux 1:'
+
+        # Determine handedness
+        if servo in [self.core.left_servo, self.core.left_aux_1_servo]:
+            handedness = 'Left'
+        else:
+            handedness = 'Right'
+
+        title = template % handedness
         message = '%d / %d / %d' % (servo.servo_min, servo.servo_mid, servo.servo_max)
 
         self.set_display_contents(title=title, message=message)

--- a/launcher.py
+++ b/launcher.py
@@ -76,7 +76,7 @@ class launcher:
         # Show state on OLED display
         self.show_mode()
 
-    def show_message(self, title, message=''):
+    def show_message(self, title='', message=''):
         """ Show state on OLED display """
         # Clear Screen
         self.oled.cls()
@@ -98,7 +98,7 @@ class launcher:
             self.MODE_MAZE: 'Maze',
             self.MODE_CALIBRATION: 'Calibration',
         }
-        self.show_message('Mode: %s' % mode_map[self.mode])
+        self.show_message(title='Mode: %s' % mode_map[self.mode])
 
     def show_motor_config(self, left):
         """ Show motor/aux config on OLED display """
@@ -119,11 +119,7 @@ class launcher:
     def display_config(self, title, servo):
         message = '%d / %d / %d' % (servo.servo_min, servo.servo_mid, servo.servo_max)
 
-        self.oled.cls()  # Clear Screen
-        self.oled.canvas.text((10, 10), title, fill=1)
-        self.oled.canvas.text((10, 30), message, fill=1)
-        # Now show the mesasge on the screen
-        self.oled.display()
+        self.show_message(title=title, message=message)
 
     def read_config(self):
         # Read the config file when starting up.
@@ -183,20 +179,17 @@ class launcher:
     def run(self):
         """ Main Running loop controling bot mode and menu state """
         # Show state on OLED display
-        self.show_message('Booting...')
+        self.show_message(title='Booting...')
 
         # Read config file FIRST
         self.read_config()
 
-        self.show_message('Initialising Bluetooth...')
+        self.show_message(title='Initialising Bluetooth...')
 
         # Never stop looking for wiimote.
         while not self.killed:
             # Show state on OLED display
-            self.oled.cls()  # Clear screen
-            self.oled.canvas.text((10, 10), 'Waiting for WiiMote...', fill=1)
-            self.oled.canvas.text((10, 30), '***Press 1+2 now ***', fill=1)
-            self.oled.display()
+            self.show_message(title='Waiting for WiiMote...', message='***Press 1+2 now ***')
 
             self.wiimote = None
             try:
@@ -272,4 +265,4 @@ if __name__ == "__main__":
         print("Stopping")
         print(str(e))
         # Show state on OLED display
-        launcher.show_message('Exited Python Code')
+        launcher.show_message(title='Exited Python Code')

--- a/launcher.py
+++ b/launcher.py
@@ -54,7 +54,7 @@ class launcher:
     def stop_threads(self):
         """ Single point of call to stop any RC or Challenge Threads """
         if self.challenge:
-            if (self.mode == self.MODE_CALIBRATION):
+            if self.mode == self.MODE_CALIBRATION:
                 # Write the config file when exiting the calibration module.
                 self.challenge.write_config()
 
@@ -162,8 +162,7 @@ class launcher:
 
         # Inform user we are about to start RC mode
         logging.info("Entering into Calibration Mode")
-        self.challenge = \
-            Calibration.Calibration(self.core, self.wiimote, self)
+        self.challenge = Calibration.Calibration(self.core, self.wiimote, self)
 
         # Create and start a new thread
         # running the remote control script
@@ -189,7 +188,10 @@ class launcher:
         # Never stop looking for wiimote.
         while not self.killed:
             # Show state on OLED display
-            self.show_message(title='Waiting for WiiMote...', message='***Press 1+2 now ***')
+            self.show_message(
+                title='Waiting for WiiMote...',
+                message='***Press 1+2 now ***'
+            )
 
             self.wiimote = None
             try:


### PR DESCRIPTION
This PR is a roll-up of #8 and #9, and also amends the `show_message` function so that it can display both title and message as required. This function is now name as `set_display_contents` to better reflect that, and is use throughout `launcher.py`.

