### PR TITLE
Added debounce to launcher

### DIFF
--- a/debounce.py
+++ b/debounce.py
@@ -1,0 +1,19 @@
+from threading import Timer
+
+
+def debounce(wait):
+    """ Decorator that will postpone a functions
+        execution until after wait seconds
+        have elapsed since the last time it was invoked. """
+    def decorator(fn):
+        def debounced(*args, **kwargs):
+            def call_it():
+                fn(*args, **kwargs)
+            try:
+                debounced.t.cancel()
+            except(AttributeError):
+                pass
+            debounced.t = Timer(wait, call_it)
+            debounced.t.start()
+        return debounced
+    return decorator

--- a/launcher.py
+++ b/launcher.py
@@ -16,6 +16,7 @@ from lib_oled96 import ssd1306
 import VL53L0X
 # from smbus import SMBus  # Commented out as I don't believe its required.
 from enum import Enum
+from debounce import debounce
 
 try:
     from collections import OrderedDict
@@ -94,6 +95,7 @@ class launcher:
         # Show state on OLED display
         self.show_menu()
 
+    @debounce(0.25)
     def menu_item_pressed(self):
         """ Current menu item pressed. Do something """
         if self.menu_mode == Mode.MODE_POWER:


### PR DESCRIPTION
As suggested, I've added a menu item debounce of 0.25 seconds between menu button presses. Once this is merged back to master, I can continue the upgrade so that more menu items and calibration buttons are debounced sensibly.